### PR TITLE
Remove `isPlottable` computed property

### DIFF
--- a/Skewt/Model/SkewtPlot.swift
+++ b/Skewt/Model/SkewtPlot.swift
@@ -50,7 +50,7 @@ struct SkewtPlot {
     var skewSlope: CGFloat
     
     var temperaturePath: CGPath? {
-        guard let data = sounding?.data.filter({ $0.isPlottable }),
+        guard let data = sounding?.data.filter({ $0.temperature != nil }),
               data.count > 0 else {
             return nil
         }
@@ -76,7 +76,7 @@ struct SkewtPlot {
     }
     
     var dewPointPath: CGPath? {
-        guard let data = sounding?.data.filter({ $0.isPlottable }),
+        guard let data = sounding?.data.filter({ $0.dewPoint != nil }),
               data.count > 0 else {
             return nil
         }

--- a/Skewt/Model/Sounding.swift
+++ b/Skewt/Model/Sounding.swift
@@ -54,11 +54,6 @@ struct LevelDataPoint: Codable {
     let dewPoint: Double?
     let windDirection: Int?
     let windSpeed: Int?
-    
-    // Does this point contain at least temperature and dew point so it can be plotted?
-    var isPlottable: Bool {
-        temperature != nil && dewPoint != nil
-    }
 }
 
 enum SoundingParseError: Error, Codable {

--- a/SkewtTests/SkewTPlotTests.swift
+++ b/SkewtTests/SkewTPlotTests.swift
@@ -218,14 +218,14 @@ RAOB sounding valid at:
     func testDataToCoordinateAndBack() {
         let plot = SkewtPlot(sounding: sounding)
 
-        let data = sounding.data.filter({ $0.isPlottable }).first!
+        let data = sounding.data.filter({ $0.temperature != nil }).first!
         let expected = (pressure: data.pressure, temperature: data.temperature!)
         let pointFromPlot = plot.point(pressure: expected.pressure, temperature: expected.temperature)
         let recalculatedData = plot.pressureAndTemperature(atPoint: pointFromPlot)
         XCTAssertEqual(recalculatedData.pressure, expected.pressure, accuracy: 0.001)
         XCTAssertEqual(recalculatedData.temperature, expected.temperature, accuracy: 0.001)
         
-        let data2 = sounding.data.filter({ $0.isPlottable }).last!
+        let data2 = sounding.data.filter({ $0.temperature != nil }).last!
         let expected2 = (pressure: data2.pressure, temperature: data2.temperature!)
         let pointFromPlot2 = plot.point(pressure: expected2.pressure, temperature: expected2.temperature)
         let recalculatedData2 = plot.pressureAndTemperature(atPoint: pointFromPlot2)
@@ -236,7 +236,7 @@ RAOB sounding valid at:
     func testCoordinateToPointAndBack() {
         let plot = SkewtPlot(sounding: sounding)
 
-        let data = sounding.data.filter({ $0.isPlottable })[15]
+        let data = sounding.data.filter({ $0.temperature != nil })[15]
         let point = plot.point(pressure: data.pressure, temperature: data.temperature!)
         let dataFromPoint = plot.pressureAndTemperature(atPoint: point)
         let recalculatedPoint = plot.point(pressure: dataFromPoint.pressure, temperature: dataFromPoint.temperature)

--- a/SkewtTests/SkewtTests.swift
+++ b/SkewtTests/SkewtTests.swift
@@ -154,7 +154,6 @@ class SkewtTests: XCTestCase {
     func testDataPointParsing() throws {
         let mandatoryLine = "      4   2500  10313   -525   -574    256     36"
         let mandatory = try LevelDataPoint(fromText: mandatoryLine)
-        XCTAssertTrue(mandatory.isPlottable)
         XCTAssertEqual(mandatory.type, .mandatoryLevel)
         XCTAssertEqual(mandatory.pressure, 250.0)
         XCTAssertEqual(mandatory.height, 10313)
@@ -165,7 +164,6 @@ class SkewtTests: XCTestCase {
         
         let significantLine = "      5   2331  10762   -553   -602    235     36"
         let significant = try LevelDataPoint(fromText: significantLine)
-        XCTAssertTrue(significant.isPlottable)
         XCTAssertEqual(significant.type, .significantLevel)
         XCTAssertEqual(significant.pressure, 233.1)
         XCTAssertEqual(significant.height, 10762)
@@ -176,7 +174,6 @@ class SkewtTests: XCTestCase {
         
         let mandatoryLineWithBlanks = "      4   8500  99999  99999  99999  99999  99999"
         let blanks = try LevelDataPoint(fromText: mandatoryLineWithBlanks)
-        XCTAssertFalse(blanks.isPlottable)
         XCTAssertEqual(blanks.type, .mandatoryLevel)
         XCTAssertEqual(blanks.pressure, 850.0)
         XCTAssertNil(blanks.temperature)
@@ -186,7 +183,6 @@ class SkewtTests: XCTestCase {
         
         let windLine = "      6    262  24384  99999  99999     40     10   1235     88     90"
         let wind = try LevelDataPoint(fromText: windLine)
-        XCTAssertFalse(wind.isPlottable)
         XCTAssertEqual(wind.type, .windLevel)
         XCTAssertNil(wind.temperature)
         XCTAssertNil(wind.dewPoint)
@@ -215,7 +211,7 @@ class SkewtTests: XCTestCase {
         XCTAssertEqual(sounding.type, .op40)
         XCTAssertEqual(sounding.description, "Op40 analysis valid for grid point 6.9 nm / 66 deg from SAN:")
         XCTAssertEqual(sounding.data.count, 62)
-        XCTAssertEqual(sounding.data.filter({ $0.isPlottable }).count, 62)
+        XCTAssertEqual(sounding.data.filter({ $0.temperature != nil && $0.dewPoint != nil }).count, 62)
         XCTAssertEqual(sounding.stationId, "SAN")
         XCTAssertEqual(sounding.cape, 0)
         XCTAssertEqual(sounding.cin, 0)
@@ -248,7 +244,7 @@ class SkewtTests: XCTestCase {
         XCTAssertEqual(sounding.type, .raob)
         XCTAssertEqual(sounding.description, "RAOB sounding valid at:")
         XCTAssertEqual(sounding.data.count, 231)
-        XCTAssertEqual(sounding.data.filter({ $0.isPlottable }).count, 89)
+        XCTAssertEqual(sounding.data.filter({ $0.temperature != nil && $0.dewPoint != nil }).count, 89)
         XCTAssertEqual(sounding.stationId, "NKX")
     }
     
@@ -265,7 +261,7 @@ class SkewtTests: XCTestCase {
         XCTAssertEqual(sounding.cape, 0)
         XCTAssertEqual(sounding.cin, 0)
         XCTAssertEqual(sounding.data.count, 39)
-        XCTAssertEqual(sounding.data.filter({ $0.isPlottable }).count, 39)
+        XCTAssertEqual(sounding.data.filter({ $0.temperature != nil && $0.dewPoint != nil }).count, 39)
     }
     
     func testGfsParsing() throws {
@@ -281,7 +277,7 @@ class SkewtTests: XCTestCase {
         XCTAssertEqual(sounding.cape, 0)
         XCTAssertEqual(sounding.cin, 0)
         XCTAssertEqual(sounding.data.count, 31)
-        XCTAssertEqual(sounding.data.filter({ $0.isPlottable }).count, 26)
+        XCTAssertEqual(sounding.data.filter({ $0.temperature != nil && $0.dewPoint != nil }).count, 26)
     }
     
     func testGlobalsParsing() {


### PR DESCRIPTION
This property never made much sense. Callers want either temperature or dew point or wind or some combination, depending on use. Let them filter themselves.

![image](https://github.com/jasonn85/Skewt/assets/1328743/d8397677-2dfd-456f-8039-cc537c5afc73)
