### PR TITLE
Refresh recent soundings list after initial refresh on load.

### DIFF
--- a/Skewt/ContentView.swift
+++ b/Skewt/ContentView.swift
@@ -58,6 +58,7 @@ struct ContentView: View {
                 
                 AnnotatedSkewtPlotView().environmentObject(store).onAppear() {
                     store.dispatch(LocationState.Action.requestLocation)
+                    store.dispatch(RecentSoundingsState.Action.refresh)
                     store.dispatch(SoundingState.Action.doRefresh)
                 }
                 


### PR DESCRIPTION
Fixes https://github.com/jasonn85/Skewt/issues/49 by grabbing a list of soundings on initial load

![image](https://github.com/jasonn85/Skewt/assets/1328743/96df4b75-bcaa-4138-a36b-d69f2cba75dc)
