### PR TITLE
Specify "now" time instead of relying on NOAA API

### DIFF
--- a/Skewt/State/Middleware/RucApiMiddleware.swift
+++ b/Skewt/State/Middleware/RucApiMiddleware.swift
@@ -161,12 +161,13 @@ extension SoundingRequest {
         
         switch selection.time {
         case .now:
-            startTime = nil
+            startTime = Date.nearestHour(withIntervalFromNow: 0, hoursPerInterval: selection.type.hourInterval)
+            endTime = startTime!.addingTimeInterval(.hours(selection.type.hourInterval))
         case .relative(let timeInterval):
             switch selection.type {
             case .op40:
-                startTime = Date(timeIntervalSinceNow: timeInterval)
-                endTime = Date(timeIntervalSinceNow: timeInterval + .hours(1))
+                startTime = Date.nearestHour(withIntervalFromNow: timeInterval, hoursPerInterval: selection.type.hourInterval)
+                endTime = startTime!.addingTimeInterval(.hours(selection.type.hourInterval))
             case .raob:
                 startTime = timeInterval.closestSoundingTime()
             }


### PR DESCRIPTION
Their API makes strange choices as to what the nearest model time should be. This sometimes caused two hour gaps between now and the next available selection.

![image](https://github.com/jasonn85/Skewt/assets/1328743/fbb90d79-b207-4930-8aa2-2af8692b0d6d)
