### PR TITLE
Fix wind barb misplacement/general missizing of the UI around the plot

### DIFF
--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -177,7 +177,7 @@ struct AnnotatedSkewtPlotView: View {
                             .gesture(
                                 DragGesture(minimumDistance: 0.0)
                                     .onChanged {
-                                        updateAnnotationPoint($0.location, inRect: CGRect(origin: .zero, size: plotSize))
+                                        updateAnnotationPoint($0.location)
                                     }
                             )
                         
@@ -300,10 +300,10 @@ struct AnnotatedSkewtPlotView: View {
         }
     }
     
-    private func updateAnnotationPoint(_ point: CGPoint, inRect rect: CGRect) {
+    private func updateAnnotationPoint(_ point: CGPoint) {
         annotationPoint = CGPoint(
-            x: point.x / rect.size.width,
-            y: point.y / rect.size.height
+            x: point.x / plotSize.width,
+            y: point.y / plotSize.height
         )
     }
     

--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -198,8 +198,10 @@ struct AnnotatedSkewtPlotView: View {
             }
         }
         .aspectRatio(1.0, contentMode: .fit)
-        .onPreferenceChange(PlotSizePreferenceKey.self) {
-            self.plotSize = $0
+        .onPreferenceChange(PlotSizePreferenceKey.self) { preference in
+            withAnimation {
+                self.plotSize = preference
+            }
         }
     }
     

--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -471,6 +471,9 @@ extension View {
 
 struct AnnotatedSkewtPlotView_Previews: PreviewProvider {
     static var previews: some View {
-        AnnotatedSkewtPlotView().environmentObject(Store<SkewtState>.previewStore)
+        let store = Store<SkewtState>.previewStore
+        let _ = store.dispatch(PlotOptions.Action.setWindBarbs(true))
+        
+        AnnotatedSkewtPlotView().environmentObject(store)
     }
 }

--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -148,39 +148,37 @@ struct AnnotatedSkewtPlotView: View {
                     yAxisLabelView(withPlot: plot)
                         .gridCellUnsizedAxes(.vertical)
                     
-                    GeometryReader { geometry in
-                        ZStack {
-                            SkewtPlotView(plot: plot)
-                                .environmentObject(store)
-                                .aspectRatio(1.0, contentMode: .fit)
-                                .border(.black)
-                                .overlay {
-                                    GeometryReader { geometry in
-                                        Rectangle()
-                                            .opacity(0.0)
-                                            .preference(key: PlotSizePreferenceKey.self, value: geometry.size)
-                                    }
+                    ZStack {
+                        SkewtPlotView(plot: plot)
+                            .environmentObject(store)
+                            .aspectRatio(1.0, contentMode: .fit)
+                            .border(.black)
+                            .overlay {
+                                GeometryReader { geometry in
+                                    Rectangle()
+                                        .opacity(0.0)
+                                        .preference(key: PlotSizePreferenceKey.self, value: geometry.size)
                                 }
-                                .background {
-                                    LinearGradient(
-                                        colors: [Color("LowSkyBlue"), Color("HighSkyBlue")],
-                                        startPoint: .bottom,
-                                        endPoint: .top
-                                    )
-                                }
-                                .gesture(
-                                    DragGesture(minimumDistance: 0.0)
-                                        .onChanged {
-                                            updateAnnotationPoint($0.location, geometryProxy: geometry)
-                                        }
+                            }
+                            .background {
+                                LinearGradient(
+                                    colors: [Color("LowSkyBlue"), Color("HighSkyBlue")],
+                                    startPoint: .bottom,
+                                    endPoint: .top
                                 )
-                            
-                            annotations(
-                                inBounds: CGRect(x: 0.0, y: 0.0, width: geometry.size.width, height: geometry.size.height),
-                                fromPlot: plot
+                            }
+                            .gesture(
+                                DragGesture(minimumDistance: 0.0)
+                                    .onChanged {
+                                        updateAnnotationPoint($0.location, inRect: CGRect(origin: .zero, size: plotSize))
+                                    }
                             )
-                            .clipped()
-                        }
+                        
+                        annotations(
+                            inBounds: CGRect(origin: .zero, size: plotSize),
+                            fromPlot: plot
+                        )
+                        .clipped()
                     }
                     
                     windBarbView(withPlot: plot)
@@ -299,10 +297,10 @@ struct AnnotatedSkewtPlotView: View {
         }
     }
     
-    private func updateAnnotationPoint(_ point: CGPoint, geometryProxy geometry: GeometryProxy) {
+    private func updateAnnotationPoint(_ point: CGPoint, inRect rect: CGRect) {
         annotationPoint = CGPoint(
-            x: point.x / geometry.size.width,
-            y: point.y / geometry.size.height
+            x: point.x / rect.size.width,
+            y: point.y / rect.size.height
         )
     }
     

--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -330,22 +330,26 @@ struct AnnotatedSkewtPlotView: View {
                 .foregroundColor(.clear)
                 .frame(width: 0.0, height: 0.0)
         } else {
-            Rectangle().frame(width: yAxisLabelWidthOrNil!).foregroundColor(.clear).overlay {
-                GeometryReader { geometry in
-                    let isobars = isobars(withPlot: plot)
-                    
-                    ForEach(isobars.keys.sorted().reversed(), id: \.self) { key in
-                        Text(isobarAxisLabelFormatter.string(from: key as NSNumber) ?? "")
-                            .font(Font(leftAxisLabelFont))
-                            .lineLimit(1)
-                            .foregroundColor(isobarColor)
-                            .position(
-                                x: geometry.size.width / 2.0,
-                                y: yForIsobar(key, inPlot: plot) * plotSize.height
-                            )
+            Rectangle()
+                .frame(width: yAxisLabelWidthOrNil!)
+                .foregroundColor(.clear)
+                .overlay {
+                    GeometryReader { geometry in
+                        let isobars = isobars(withPlot: plot)
+                        
+                        ForEach(isobars.keys.sorted().reversed(), id: \.self) { key in
+                            Text(isobarAxisLabelFormatter.string(from: key as NSNumber) ?? "")
+                                .font(Font(leftAxisLabelFont))
+                                .lineLimit(1)
+                                .foregroundColor(isobarColor)
+                                .position(
+                                    x: geometry.size.width / 2.0,
+                                    y: yForIsobar(key, inPlot: plot) * plotSize.height
+                                )
+                        }
                     }
+                    
                 }
-            }
         }
     }
     
@@ -354,25 +358,28 @@ struct AnnotatedSkewtPlotView: View {
         if xAxisLabelHeightOrNil == nil {
             EmptyView()
         } else {
-            Rectangle().frame(height: xAxisLabelHeightOrNil!).foregroundColor(.clear).overlay {
-                GeometryReader { geometry in
-                    if store.state.plotOptions.showIsothermLabels {
-                        let isotherms = plot.isothermPaths
-                        ForEach(isotherms.keys.sorted(), id: \.self) { temperature in
-                            let x = plot.x(forSurfaceTemperature: temperature) * plotSize.width
-                            if x >= 0 {
-                                Text(String(Int(temperature)))
-                                    .font(Font(bottomAxisLabelFont))
-                                    .foregroundColor(isothermColor)
-                                    .position(
-                                        x: x,
-                                        y: geometry.size.height / 2.0
-                                    )
+            Rectangle()
+                .frame(height: xAxisLabelHeightOrNil!)
+                .foregroundColor(.clear)
+                .overlay {
+                    GeometryReader { geometry in
+                        if store.state.plotOptions.showIsothermLabels {
+                            let isotherms = plot.isothermPaths
+                            ForEach(isotherms.keys.sorted(), id: \.self) { temperature in
+                                let x = plot.x(forSurfaceTemperature: temperature) * plotSize.width
+                                if x >= 0 {
+                                    Text(String(Int(temperature)))
+                                        .font(Font(bottomAxisLabelFont))
+                                        .foregroundColor(isothermColor)
+                                        .position(
+                                            x: x,
+                                            y: geometry.size.height / 2.0
+                                        )
+                                }
                             }
                         }
                     }
                 }
-            }
         }
     }
     

--- a/Skewt/Views/AnnotatedSkewtPlotView.swift
+++ b/Skewt/Views/AnnotatedSkewtPlotView.swift
@@ -156,8 +156,15 @@ struct AnnotatedSkewtPlotView: View {
                             .overlay {
                                 GeometryReader { geometry in
                                     Rectangle()
-                                        .opacity(0.0)
+                                        .foregroundColor(.clear)
                                         .preference(key: PlotSizePreferenceKey.self, value: geometry.size)
+                                        .overlay {
+                                            annotations(
+                                                inBounds: CGRect(origin: .zero, size: plotSize),
+                                                fromPlot: plot
+                                            )
+                                            .clipped()
+                                        }
                                 }
                             }
                             .background {
@@ -174,11 +181,7 @@ struct AnnotatedSkewtPlotView: View {
                                     }
                             )
                         
-                        annotations(
-                            inBounds: CGRect(origin: .zero, size: plotSize),
-                            fromPlot: plot
-                        )
-                        .clipped()
+                        
                     }
                     
                     windBarbView(withPlot: plot)


### PR DESCRIPTION
- Add a preference key to store the plot size. Use that to size everything else around the plot: axis labels, annotations, wind barbs, etc.
- Fixes https://github.com/jasonn85/Skewt/issues/60

![image](https://github.com/jasonn85/Skewt/assets/1328743/f9e7d0ec-1819-473c-a8f9-4777e4ec15ac)
