### PR TITLE
Prevent loading sounding data that is not yet available

### DIFF
--- a/Skewt.xcodeproj/project.pbxproj
+++ b/Skewt.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		96D0A4312A3AFA1E009BE6FD /* SoundingSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D0A4302A3AFA1E009BE6FD /* SoundingSelectionView.swift */; };
 		96D30F302A83581200986E7E /* WindBarb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D30F2F2A83581200986E7E /* WindBarb.swift */; };
 		96DFD48E2A030B670095BC79 /* AnnotatedSkewtPlotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96DFD48D2A030B670095BC79 /* AnnotatedSkewtPlotView.swift */; };
+		96E0A95F2B2901680076B87A /* UpdateRAOBTimeMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E0A95E2B2901680076B87A /* UpdateRAOBTimeMiddleware.swift */; };
 		96E334EF2A22963A00B90043 /* ConsoleLogMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E334EE2A22963A00B90043 /* ConsoleLogMiddleware.swift */; };
 		96E334F12A26757200B90043 /* LocationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E334F02A26757200B90043 /* LocationStateTests.swift */; };
 		96E334F32A2707E700B90043 /* DisplayOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E334F22A2707E700B90043 /* DisplayOptionsView.swift */; };
@@ -145,6 +146,7 @@
 		96D0A4302A3AFA1E009BE6FD /* SoundingSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundingSelectionView.swift; sourceTree = "<group>"; };
 		96D30F2F2A83581200986E7E /* WindBarb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindBarb.swift; sourceTree = "<group>"; };
 		96DFD48D2A030B670095BC79 /* AnnotatedSkewtPlotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotatedSkewtPlotView.swift; sourceTree = "<group>"; };
+		96E0A95E2B2901680076B87A /* UpdateRAOBTimeMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateRAOBTimeMiddleware.swift; sourceTree = "<group>"; };
 		96E334EE2A22963A00B90043 /* ConsoleLogMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogMiddleware.swift; sourceTree = "<group>"; };
 		96E334F02A26757200B90043 /* LocationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationStateTests.swift; sourceTree = "<group>"; };
 		96E334F22A2707E700B90043 /* DisplayOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayOptionsView.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				96FE7E532A3A8C030069AD3A /* SoundingsListApiMiddleware.swift */,
 				967E2D042A3D7CAF0074CE1F /* UserDefaultsMiddleware.swift */,
 				960092782A5A2DE500BCBAD0 /* LocationSearchMiddleware.swift */,
+				96E0A95E2B2901680076B87A /* UpdateRAOBTimeMiddleware.swift */,
 			);
 			path = Middleware;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				969B8BC42AFEE986002D0F20 /* SoundingWindData.swift in Sources */,
 				96A8F5E3299DAC3E0021A170 /* SkewtApp.swift in Sources */,
 				967E2D052A3D7CAF0074CE1F /* UserDefaultsMiddleware.swift in Sources */,
+				96E0A95F2B2901680076B87A /* UpdateRAOBTimeMiddleware.swift in Sources */,
 				96F4B05E29A80396006D23BE /* Store.swift in Sources */,
 				96F4B06029A804E1006D23BE /* SoundingRequest.swift in Sources */,
 				96590BA22A1D6562001143DB /* HourlyTimeSelectView.swift in Sources */,

--- a/Skewt/ContentView.swift
+++ b/Skewt/ContentView.swift
@@ -197,6 +197,8 @@ struct ContentView: View {
                 return "Request failed"
             case .unableToGenerateRequestFromSelection:
                 return "Error creating request"
+            case .emptyResponse:
+                return "No data is available"
             case .unparseableResponse:
                 return "Data was not parseable"
             }

--- a/Skewt/Model/SoundingLocationList.swift
+++ b/Skewt/Model/SoundingLocationList.swift
@@ -30,6 +30,14 @@ struct LatestSoundingList: Codable, Equatable {
     var soundings: [Entry]
 }
 
+extension LatestSoundingList {
+    func lastSoundingTime(forWmoId wmoId: Int) -> Date? {
+        let entry = soundings.first(where: { $0.stationId == .wmoId(wmoId) })
+        
+        return entry?.timestamp
+    }
+}
+
 struct LocationList: Codable {
     struct Location: Codable, Hashable, Identifiable {
         var name: String

--- a/Skewt/Model/SoundingLocationList.swift
+++ b/Skewt/Model/SoundingLocationList.swift
@@ -32,9 +32,7 @@ struct LatestSoundingList: Codable, Equatable {
 
 extension LatestSoundingList {
     func lastSoundingTime(forWmoId wmoId: Int) -> Date? {
-        let entry = soundings.first(where: { $0.stationId == .wmoId(wmoId) })
-        
-        return entry?.timestamp
+        soundings.first(where: { $0.stationId == .wmoId(wmoId) })?.timestamp
     }
 }
 

--- a/Skewt/SkewtApp.swift
+++ b/Skewt/SkewtApp.swift
@@ -19,7 +19,8 @@ struct SkewtApp: App {
                 Middlewares.locationMiddleware,
                 Middlewares.consoleLogger,
                 Middlewares.userDefaultsSaving,
-                Middlewares.locationSearchMiddleware
+                Middlewares.locationSearchMiddleware,
+                Middlewares.updateRaobTimeMiddleware
             ]
         )
         

--- a/Skewt/State/Middleware/RucApiMiddleware.swift
+++ b/Skewt/State/Middleware/RucApiMiddleware.swift
@@ -52,8 +52,12 @@ extension Middlewares {
                 return URLSession.shared.dataTaskPublisher(for: url)
                     .map { data, response in
                         guard !data.isEmpty,
-                              let text = String(data: data, encoding: .utf8),
-                              let sounding = try? Sounding(fromText: text) else {
+                                let text = String(data: data, encoding: .utf8),
+                                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                            return SoundingState.Action.didReceiveFailure(.emptyResponse)
+                        }
+                        
+                        guard let sounding = try? Sounding(fromText: text) else {
                             return SoundingState.Action.didReceiveFailure(.unparseableResponse)
                         }
                         

--- a/Skewt/State/Middleware/UpdateRAOBTimeMiddleware.swift
+++ b/Skewt/State/Middleware/UpdateRAOBTimeMiddleware.swift
@@ -12,12 +12,12 @@ extension Middlewares {
     /// This middleware detects if our current selection is most recent sounding and we just received a list of
     /// available soundings that shows the latest data is older than one sounding ago (so the request will return blank data)
     static let updateRaobTimeMiddleware: Middleware<SkewtState> = { state, action in
-        guard case RecentSoundingsState.Action.didReceiveList(let soundingList) = action,
-              case SoundingSelection.ModelType.raob = state.currentSoundingState.selection.type,
-              case SoundingSelection.Location.named(let locationName) = state.currentSoundingState.selection.location,
+        guard case .didReceiveList(let soundingList) = action as? RecentSoundingsState.Action,
+              case .raob = state.currentSoundingState.selection.type,
+              case .named(let locationName) = state.currentSoundingState.selection.location,
               let wmoId = LocationList.allLocations.locationNamed(locationName)?.wmoId,
               let mostRecentSounding = soundingList.lastSoundingTime(forWmoId: wmoId),
-              case SoundingSelection.Time.numberOfSoundingsAgo(let soundingsAgo) = mostRecentSounding.soundingSelectionTime(forModelType: .raob),
+              case .numberOfSoundingsAgo(let soundingsAgo) = mostRecentSounding.soundingSelectionTime(forModelType: .raob),
               soundingsAgo > 1
         else {
             return Empty().eraseToAnyPublisher()

--- a/Skewt/State/Middleware/UpdateRAOBTimeMiddleware.swift
+++ b/Skewt/State/Middleware/UpdateRAOBTimeMiddleware.swift
@@ -1,0 +1,29 @@
+//
+//  UpdateRAOBTimeMiddleware.swift
+//  Skewt
+//
+//  Created by Jason Neel on 12/12/23.
+//
+
+import Foundation
+import Combine
+
+extension Middlewares {
+    /// This middleware detects if our current selection is most recent sounding and we just received a list of
+    /// available soundings that shows the latest data is older than one sounding ago (so the request will return blank data)
+    static let updateRaobTimeMiddleware: Middleware<SkewtState> = { state, action in
+        guard case RecentSoundingsState.Action.didReceiveList(let soundingList) = action,
+              case SoundingSelection.ModelType.raob = state.currentSoundingState.selection.type,
+              case SoundingSelection.Location.named(let locationName) = state.currentSoundingState.selection.location,
+              let wmoId = LocationList.allLocations.locationNamed(locationName)?.wmoId,
+              let mostRecentSounding = soundingList.lastSoundingTime(forWmoId: wmoId),
+              case SoundingSelection.Time.numberOfSoundingsAgo(let soundingsAgo) = mostRecentSounding.soundingSelectionTime(forModelType: .raob),
+              soundingsAgo > 1
+        else {
+            return Empty().eraseToAnyPublisher()
+        }
+        
+        return Just(SoundingState.Action.changeAndLoadSelection(.selectTime(.numberOfSoundingsAgo(soundingsAgo))))
+            .eraseToAnyPublisher()
+    }
+}

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -150,6 +150,7 @@ extension SoundingSelection {
 struct SoundingState: Codable {
     enum SoundingError: Error, Codable {
         case unableToGenerateRequestFromSelection
+        case emptyResponse
         case unparseableResponse
         case requestFailed
         case lackingLocationPermission  // We can't do closest weather if we lack CL permission

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct SoundingSelection: Codable, Hashable, Identifiable {
     enum Action: Skewt.Action {
-        case selectModelType(ModelType)
-        case selectLocation(Location)
+        case selectModelType(ModelType, Time = .now)
+        case selectLocation(Location, Time = .now)
         case selectTime(Time)
-        case selectModelTypeAndLocation(ModelType?, Location?)
+        case selectModelTypeAndLocation(ModelType?, Location?, Time = .now)
     }
     
     enum ModelType: Codable, CaseIterable, Identifiable, Equatable {
@@ -112,17 +112,17 @@ extension SoundingSelection {
         }
         
         switch action {
-        case .selectModelType(let type):
-            return SoundingSelection(type: type, location: state.location, time: .now)
-        case .selectLocation(let location):
-            return SoundingSelection(type: state.type, location: location, time: state.time)
+        case .selectModelType(let type, let time):
+            return SoundingSelection(type: type, location: state.location, time: time)
+        case .selectLocation(let location, let time):
+            return SoundingSelection(type: state.type, location: location, time: time)
         case .selectTime(let time):
             return SoundingSelection(type: state.type, location: state.location, time: time)
-        case .selectModelTypeAndLocation(let type, let location):
+        case .selectModelTypeAndLocation(let type, let location, let time):
             return SoundingSelection(
                 type: type ?? state.type,
                 location: location ?? state.location,
-                time: .now
+                time: time
             )
         }
     }
@@ -261,9 +261,9 @@ extension SoundingSelection.Action {
     // Is this action changing the sounding type or location?
     var isCreatingNewSelection: Bool {
         switch self {
-        case .selectModelTypeAndLocation(let type, let location):
+        case .selectModelTypeAndLocation(let type, let location, _):
             return type != nil || location != nil
-        case .selectLocation(_), .selectModelType(_):
+        case .selectLocation(_, _), .selectModelType(_, _):
             return true
         case .selectTime(_):
             // Just changing time is not creating a new selection type

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -113,7 +113,7 @@ extension SoundingSelection {
         
         switch action {
         case .selectModelType(let type):
-            return SoundingSelection(type: type, location: state.location, time: state.time)
+            return SoundingSelection(type: type, location: state.location, time: .now)
         case .selectLocation(let location):
             return SoundingSelection(type: state.type, location: location, time: state.time)
         case .selectTime(let time):

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -83,6 +83,25 @@ extension SoundingSelection {
     }
 }
 
+extension Date {
+    func soundingSelectionTime(forModelType modelType: SoundingSelection.ModelType, referenceDate: Date = .now) -> SoundingSelection.Time {
+        let timeInterval = timeIntervalSince(referenceDate)
+
+        switch modelType {
+        case .op40:
+            return timeInterval == 0.0 ? .now : .relative(timeInterval)
+        case .raob:
+            let intervalCount = Int(round(timeInterval / 60.0 / 60.0 / Double(modelType.hourInterval)))
+            
+            if abs(intervalCount) <= 1 {
+                return .now
+            } else {
+                return .numberOfSoundingsAgo(-intervalCount)
+            }
+        }
+    }
+}
+
 extension SoundingSelection: CustomStringConvertible {
     var description: String {
         location.briefDescription

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -55,6 +55,17 @@ extension SoundingSelection {
     }
 }
 
+extension SoundingSelection.Location {
+    var nameOrNil: String? {
+        switch self {
+        case .named(let name):
+            return name
+        case .closest, .point(_, _):
+            return nil
+        }
+    }
+}
+
 extension SoundingSelection {
     var requiresLocation: Bool {
         switch self.location {

--- a/Skewt/State/SoundingState.swift
+++ b/Skewt/State/SoundingState.swift
@@ -55,17 +55,6 @@ extension SoundingSelection {
     }
 }
 
-extension SoundingSelection.Location {
-    var nameOrNil: String? {
-        switch self {
-        case .named(let name):
-            return name
-        case .closest, .point(_, _):
-            return nil
-        }
-    }
-}
-
 extension SoundingSelection {
     var requiresLocation: Bool {
         switch self.location {

--- a/Skewt/Views/Selection/SoundingSelectionRow.swift
+++ b/Skewt/Views/Selection/SoundingSelectionRow.swift
@@ -146,9 +146,32 @@ struct SoundingSelectionRow: View {
                 store.dispatch(SoundingState.Action.changeAndLoadSelection(
                     .selectModelTypeAndLocation(
                         selection.type,
-                        selection.location
+                        selection.location,
+                        mostRecentTime(forType: selection.type, location: selection.location)
                     )
                 ))
+            }
+        }
+    }
+    
+    private func mostRecentTime(
+        forType type: SoundingSelection.ModelType,
+        location: SoundingSelection.Location
+    ) -> SoundingSelection.Time {
+        switch type {
+        case .op40:
+            return .now
+        case .raob:
+            switch location {
+            case .closest, .point(_, _):
+                return .now
+            case .named(let name):
+                guard let wmoId = LocationList.allLocations.locationNamed(name)?.wmoId,
+                      let mostRecentSounding = store.state.recentSoundingsState.recentSoundings?.lastSoundingTime(forWmoId: wmoId) else {
+                    return .now
+                }
+                
+                return mostRecentSounding.soundingSelectionTime(forModelType: type)
             }
         }
     }

--- a/Skewt/Views/Selection/SoundingSelectionView.swift
+++ b/Skewt/Views/Selection/SoundingSelectionView.swift
@@ -101,12 +101,12 @@ struct SoundingSelectionView: View {
     }
     
     private func lastSoundingComponent(forWmoId wmoId: Int) -> SoundingSelectionRow.DescriptionComponent? {
-        guard let recentSoundings = store.state.recentSoundingsState.recentSoundings?.soundings,
-              let entry = recentSoundings.first(where:{ $0.wmoIdOrNil == wmoId }) else {
+        guard let recentSoundings = store.state.recentSoundingsState.recentSoundings,
+              let soundingTime = recentSoundings.lastSoundingTime(forWmoId: wmoId) else {
             return nil
         }
         
-        return .age(entry.timestamp)
+        return .age(soundingTime)
     }
 }
 

--- a/SkewtTests/ClosestTimeTests.swift
+++ b/SkewtTests/ClosestTimeTests.swift
@@ -173,4 +173,34 @@ final class ClosestTimeTests: XCTestCase {
             XCTAssertEqual(interval, TimeInterval(-Double(hourInterval) * 60.0 * 60.0))
         }
     }
+    
+    func testDateToSoundingSelectionTime() {
+        let referenceDate = Date(timeIntervalSince1970: 1702412771)  // December 12, 2023 20:26:11 UTC
+        
+        // op40 just spits back the time interval (or .now)
+        XCTAssertEqual(referenceDate.soundingSelectionTime(forModelType: .op40, referenceDate: referenceDate), .now)
+        let oneHour = TimeInterval(60.0 * 60.0)
+        let oneHourAgo = referenceDate.addingTimeInterval(-oneHour)
+        XCTAssertEqual(oneHourAgo.soundingSelectionTime(forModelType: .op40, referenceDate: referenceDate), .relative(-oneHour))
+        
+        // RAOB now is most recent
+        XCTAssertEqual(referenceDate.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .now)
+        
+        // RAOB minus one hour is most recent
+        XCTAssertEqual(oneHourAgo.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .now)
+        
+        // RAOB 12 hours ago is most recent
+        let twelveHoursAgo = referenceDate.addingTimeInterval(-12.0 * 60.0 * 60.0)
+        XCTAssertEqual(twelveHoursAgo.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .now)
+        
+        // RAOB 24 hours ago is +2
+        let dayAgo = referenceDate.addingTimeInterval(-24.0 * 60.0 * 60.0)
+        XCTAssertEqual(dayAgo.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .numberOfSoundingsAgo(2))
+        
+        // RAOB 23/25 hours ago is +2
+        let dayAgoMinusHour = referenceDate.addingTimeInterval(-23.0 * 60.0 * 60.0)
+        let dayAgoPlusHour = referenceDate.addingTimeInterval(-25.0 * 60.0 * 60.0)
+        XCTAssertEqual(dayAgoMinusHour.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .numberOfSoundingsAgo(2))
+        XCTAssertEqual(dayAgoPlusHour.soundingSelectionTime(forModelType: .raob, referenceDate: referenceDate), .numberOfSoundingsAgo(2))
+    }
 }


### PR DESCRIPTION
We have this information available via `RecentSoundingsState`. We shouldn't try to load data that we know won't exist.

An issue still remains with the time selection UI: https://github.com/jasonn85/Skewt/issues/70

- Closes https://github.com/jasonn85/Skewt/issues/67

![you-know-better-know-better](https://github.com/jasonn85/Skewt/assets/1328743/a0c85a8b-83d5-49c2-8c9d-1d53212e9de6)
