### PR TITLE
Prevent plot from becoming 0x0 with no content (e.g. loading data with adiabats disabled)

### DIFF
--- a/Skewt/Views/SkewtPlotView.swift
+++ b/Skewt/Views/SkewtPlotView.swift
@@ -53,7 +53,10 @@ struct SkewtPlotView: View {
             
             switch plotOptions.adiabatTypes {
             case .none:
-                EmptyView()
+                // Draw a transparent rectangle instead of an EmptyView so that the plot takes up some space
+                // if there is no data at all.
+                Rectangle()
+                    .foregroundColor(.clear)
             case .tens:
                 let dryAdiabats = plot.dryAdiabatPaths
                 ForEach(dryAdiabats.keys.sorted(), id: \.self) { t in


### PR DESCRIPTION
- Fixes https://github.com/jasonn85/Skewt/issues/66

![where](https://github.com/jasonn85/Skewt/assets/1328743/9e2595c9-58f8-4be0-965a-92b0f236693f)
