### PR TITLE
Allow plot view to expand more

### DIFF
--- a/Skewt/ContentView.swift
+++ b/Skewt/ContentView.swift
@@ -69,7 +69,8 @@ struct ContentView: View {
                     timeSelection
                 }
             }
-            
+            .layoutPriority(1.0)
+                                    
             TabView(selection: Binding<DisplayState.TabSelection>(
                 get: { store.state.displayState.tabSelection },
                 set: { store.dispatch(DisplayState.Action.selectTab($0)) }


### PR DESCRIPTION
This change is especially noticeable when using the time selection UI. Previously that UI appearing would shrink the plot; now that shrinks the details/options tab view.

![image](https://github.com/jasonn85/Skewt/assets/1328743/6b3d57db-83e5-449d-b494-761b34f850b2)
