### PR TITLE
Add retroactive annotation to fix warning

### DIFF
--- a/Skewt/Views/SkewtPlotView.swift
+++ b/Skewt/Views/SkewtPlotView.swift
@@ -133,7 +133,7 @@ struct SkewtPlotView: View {
     }
 }
 
-extension CGPath: @unchecked Sendable { }
+extension CGPath: @unchecked @retroactive Sendable { }
 
 struct PlottedPath: Shape {
     let path: CGPath


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/16064882-778c-4804-8ff7-4346cdf60f22)
