### PR TITLE
Fix menu icon colors on iPad

### DIFF
--- a/Skewt/Assets.xcassets/Menu Colors/MenuIconBackground.colorset/Contents.json
+++ b/Skewt/Assets.xcassets/Menu Colors/MenuIconBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.569",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Skewt/Views/MenuView.swift
+++ b/Skewt/Views/MenuView.swift
@@ -349,7 +349,7 @@ struct MenuView: View {
                 .overlay {
                     ZStack {
                         Rectangle()
-                            .fill(.blue)
+                            .fill(.menuIconBackground)
                         
                         image
                     }


### PR DESCRIPTION
Use a specific color for menu icons instead of OS .blue, which apparently changes via context

<img width="640" height="907" alt="image" src="https://github.com/user-attachments/assets/ac6b5d02-2a0b-43b4-9348-2843c6f1e5a7" />
